### PR TITLE
Spec updates

### DIFF
--- a/minisig.k
+++ b/minisig.k
@@ -173,7 +173,7 @@ module MINISIG
     <k> #exec SRC DST OP GAS VAL DATA SMSGS
       => #checkPrestate SRC OP VAL SMSGS
       ~> #mkCall DST OP GAS VAL DATA
-      ~> #checkPoststate OP ( NONCE +Int 1 )
+      ~> #checkPoststate
       ~> #return .RetVal
       ~> #finalize
     ...
@@ -312,38 +312,21 @@ module MINISIG
     <gas-used-pre-call> GASUSED </gas-used-pre-call>
   requires CALLGAS -Int GASUSED <Int ( TXGAS +Int gasCheckOverhead )
 
-  // --- check result of call and nonce (if delegatecall) ---
-  syntax OpRequire ::= "#checkPoststate" CallType Int
-  // - assert call succeeded
-  // - if delegatecall, assert that nonce is unchanged from before call
-
-  // call_success /\ ( op == delegate_call => nonce_unchanged )
-  // call_success /\ ( not(op == delegate_call) \/ nonce_unchanged )
+  // --- check result of call ---
+  syntax OpRequire ::= "#checkPoststate"
   rule
-    <k> #checkPoststate OP NONCE_PRECALL => . ...</k>
-    <call-success> ( ListItem ( CALLRET ) => .List ) ...</call-success>
-    <nonce> NONCE_POSTCALL </nonce>
-  requires
-    CALLRET ==Bool true
-    andBool ( notBool OP ==K DelegateCall
-              orBool NONCE_POSTCALL ==Int NONCE_PRECALL )
-
-  // TODO: this rule isnt covered by any test currently
-  rule
-    <k> #checkPoststate OP NONCE_PRECALL => #revert INVALID_POSTSTATE ...</k>
-    <nonce> NONCE_POSTCALL </nonce>
-  requires
-    OP ==K DelegateCall
-    andBool notBool NONCE_POSTCALL ==Int NONCE_PRECALL
+    <k> #checkPoststate => . ...</k>
+    <call-success> ( ListItem( CALLRET ) => .List ) ...</call-success>
+  requires CALLRET ==Bool true
 
   rule
-    <k> #checkPoststate _ _ => #revert CALL_FAILED ...</k>
+    <k> #checkPoststate => #revert CALL_FAILED ...</k>
     <call-success> ListItem(CALLRET) ...</call-success>
   requires CALLRET ==Bool false
 
   // an empty call-success list is assumed to be false
   rule
-    <k> #checkPoststate _ _ => #revert CALL_FAILED ...</k>
+    <k> #checkPoststate => #revert CALL_FAILED ...</k>
     <call-success> .List </call-success>
 
 

--- a/minisig.k
+++ b/minisig.k
@@ -36,7 +36,6 @@ module MINISIG
       <world>
         <ecrecover> .Map </ecrecover> // signature => signer
         <call-success> .List </call-success>
-        <codesize> .Map </codesize>  // address => codesize
         <gas-used-pre-call> 0:Int </gas-used-pre-call>
       </world>
 
@@ -186,7 +185,6 @@ module MINISIG
   rule
     <k> #checkPrestate OP VAL DST SMSGS
       => #checkVal OP VAL
-      ~> #checkDst OP DST
       ~> #checkSigs ( #take THRESH SMSGS )
     ...
     </k>
@@ -215,24 +213,6 @@ module MINISIG
     <balance> BAL </balance>
   requires VAL <=Int BAL
 
-  rule
-    <k> #checkVal DelegateCall VAL => . ...</k>
-    <callvalue> CALLVAL </callvalue>
-    <balance> BAL </balance>
-  requires
-    VAL <=Int BAL
-    andBool VAL ==Int CALLVAL
-
-  // -- delegatecall requires that codesize(dstAddress) > 0
-  syntax OpRequire ::= "#checkDst" CallType Address
-
-  // dst for call op can be any -- incl. 0x0, msg.sender, address(this)
-  rule #checkDst Call _ => .K
-
-  rule
-    <k> #checkDst DelegateCall DST => . ...</k>
-    <codesize>... DST |-> CSIZE ...</codesize>
-  requires CSIZE >Int 0
 
   rule
     <k> #checkDst DelegateCall DST => #revert DELEGATECALL_DST_EMPTY_CODE ...</k>

--- a/minisig.k
+++ b/minisig.k
@@ -206,15 +206,13 @@ module MINISIG
   // -- balance must be sufficient for call
   syntax OpRequire ::= "#checkVal" CallType Int
 
-  rule
-    <k> #checkVal _ VAL => #revert INVALID_VAL ...</k>
-    <balance> BAL </balance>
-  requires VAL >Int BAL
+  // value is ignored for delegatecall
+  rule #checkVal DelegateCall _ => .K
 
   rule
-    <k> #checkVal DelegateCall VAL => #revert DELEGATECALL_INVALID_CALLVAL ...</k>
-    <callvalue> CALLVAL </callvalue>
-  requires notBool VAL ==Int CALLVAL
+    <k> #checkVal Call VAL => #revert INVALID_VAL ...</k>
+    <balance> BAL </balance>
+  requires VAL >Int BAL
 
   rule
     <k> #checkVal Call VAL => . ...</k>

--- a/minisig.k
+++ b/minisig.k
@@ -20,9 +20,10 @@ module MINISIG
       </msig-state>
 
       <call>
+        <caller> 0:Address </caller>
         <callvalue> 0:Int </callvalue>
-        <returndata> .RetVal </returndata>
         <callgas> 0:Int </callgas>
+        <returndata> .RetVal </returndata>
       </call>
 
       <log>
@@ -50,10 +51,11 @@ module MINISIG
   // --- log function calls ---
   rule
     <k> #log FN => . ...</k>
+    <caller> CALLER </caller>
     <callgas> CALLGAS </callgas>
     <callvalue> CALLVAL </callvalue>
     <fn-log>
-      (.List => ListItem( { fn: FN , callvalue: CALLVAL , callgas: CALLGAS } ))
+      (.List => ListItem( { fn: FN , caller: CALLER, callvalue: CALLVAL , callgas: CALLGAS } ))
     ...
     </fn-log>
 
@@ -71,6 +73,11 @@ module MINISIG
     <k> #set1 ( gas: GAS ) => .K ...</k>
     <callgas> _ => GAS </callgas>
   requires GAS >=Int 0 andBool GAS <Int pow256
+
+  rule
+    <k> #set1 ( from: CALLER ) ...</k>
+    <caller> _ => CALLER </caller>
+  requires CALLER >Int 0 andBool CALLER <Int pow160
 
   // --- function resolution ---
 
@@ -153,19 +160,19 @@ module MINISIG
   // --- Execute ---
   // ---------------
 
-  syntax OpInternal ::= "#exec" CallType Int Int Address Data LstSignedMsg
+  syntax OpInternal ::= "#exec" AddressOrAny Address CallType Int Int Data LstSignedMsg
 
   rule
-    <k> Exec ( OP , GAS , VAL , DST , DATA , SIGS )
-      => #exec OP GAS VAL DST DATA ( #toLstSignedMsg OP GAS VAL DST DATA NONCE SIGS )
+    <k> Exec ( SRC , DST , OP , GAS , VAL , DATA , SIGS )
+      => #exec SRC DST OP GAS VAL DATA ( #toLstSignedMsg SRC DST OP GAS VAL DATA NONCE SIGS )
     ...
     </k>
     <nonce> NONCE </nonce>
 
   rule
-    <k> #exec OP GAS VAL DST DATA SMSGS
-      => #checkPrestate OP VAL DST SMSGS
-      ~> #mkCall OP GAS VAL DST DATA
+    <k> #exec SRC DST OP GAS VAL DATA SMSGS
+      => #checkPrestate SRC OP VAL SMSGS
+      ~> #mkCall DST OP GAS VAL DATA
       ~> #checkPoststate OP ( NONCE +Int 1 )
       ~> #return true
       ~> #finalize
@@ -180,11 +187,12 @@ module MINISIG
 
   // --- validate initial state ---
   syntax OpInternal ::= OpRequire
-  syntax OpRequire ::= "#checkPrestate" CallType Int Address LstSignedMsg
+  syntax OpRequire ::= "#checkPrestate" AddressOrAny CallType Int LstSignedMsg
 
   rule
-    <k> #checkPrestate OP VAL DST SMSGS
+    <k> #checkPrestate SRC OP VAL SMSGS
       => #checkVal OP VAL
+      ~> #checkSrc SRC
       ~> #checkSigs ( #take THRESH SMSGS )
     ...
     </k>
@@ -213,17 +221,18 @@ module MINISIG
     <balance> BAL </balance>
   requires VAL <=Int BAL
 
+  // -- caller must be approved to submit transaction --
+  syntax OpRequire ::= "#checkSrc" AddressOrAny
 
   rule
-    <k> #checkDst DelegateCall DST => #revert DELEGATECALL_DST_EMPTY_CODE ...</k>
-    <codesize>... DST |-> CSIZE ...</codesize>
-  requires CSIZE ==Int 0
+    <k> #checkSrc SRC => . ...</k>
+    <caller> CALLER </caller>
+  requires SRC ==K CALLER orBool SRC ==K Any
 
-  // dst address is not in codesize mapping, defaults to 0
   rule
-    <k> #checkDst DelegateCall DST => #revert DELEGATECALL_DST_EMPTY_CODE ...</k>
-    <codesize> CSIZES </codesize>
-  requires notBool (DST in_keys(CSIZES))
+    <k> #checkSrc SRC => #revert INVALID_CALLER ...</k>
+    <caller> CALLER </caller>
+  requires notBool (SRC ==K CALLER orBool SRC ==K Any)
 
   // --- validate signatures ---
   syntax OpRequire ::= "#checkSigs" LstSignedMsg
@@ -279,14 +288,14 @@ module MINISIG
     requires size ( intersectSet ( #toSet Lst1 , #toSet Lst2 ) ) <Int N
 
   // --- make external call ---
-  syntax OpInternal ::= "#mkCall" CallType Int Int Address Data
+  syntax OpInternal ::= "#mkCall" Address CallType Int Int Data
   rule
-    <k> #mkCall OP TXGAS VAL DST DATA => . ...</k>
+    <k> #mkCall DST OP TXGAS VAL DATA => . ...</k>
     <call-log>
-      .List => ListItem( { op: OP
+      .List => ListItem( { dst: DST
+                         , op: OP
                          , gas: TXGAS
                          , val: VAL
-                         , dst: DST
                          , data: DATA } )
     ...
     </call-log>
@@ -298,7 +307,7 @@ module MINISIG
     andBool BAL >=Int VAL // this should always hold at this point
 
   rule
-    <k> #mkCall _ TXGAS _ _ _ => #revert INSUFFICIENT_CALLGAS ...</k>
+    <k> #mkCall _ _ TXGAS _ _ => #revert INSUFFICIENT_CALLGAS ...</k>
     <callgas> CALLGAS </callgas>
     <gas-used-pre-call> GASUSED </gas-used-pre-call>
   requires CALLGAS -Int GASUSED <Int ( TXGAS +Int gasCheckOverhead )

--- a/minisig.k
+++ b/minisig.k
@@ -174,7 +174,7 @@ module MINISIG
       => #checkPrestate SRC OP VAL SMSGS
       ~> #mkCall DST OP GAS VAL DATA
       ~> #checkPoststate OP ( NONCE +Int 1 )
-      ~> #return true
+      ~> #return .RetVal
       ~> #finalize
     ...
     </k>

--- a/syntax.k
+++ b/syntax.k
@@ -1,16 +1,17 @@
 module MINISIG-SYNTAX
   imports DOMAINS-SYNTAX
 
-  syntax Sig      ::= String
-  syntax Data     ::= String
-  syntax Address  ::= Int
-  syntax CallType ::= "Call"
-                    | "DelegateCall"
+  syntax Sig          ::= String
+  syntax Data         ::= String
+  syntax Address      ::= Int
+  syntax AddressOrAny ::= Address | "Any"
+  syntax CallType     ::= "Call" | "DelegateCall"
 
   syntax LstSig     ::= List{Sig, ":"}
   syntax LstAddress ::= List{Address, ":"}
 
-  syntax Opt    ::= "gas:"   Int
+  syntax Opt    ::= "from:"  Address
+                  | "gas:"   Int
                   | "value:" Int
   syntax LstOpt ::= List{Opt, ","}
 
@@ -21,12 +22,13 @@ module MINISIG-SYNTAX
   syntax ViewParams ::= "(" ")"
 
   syntax FnExec     ::= "execute"
-  syntax ExecParams ::= "(" CallType                // call or delegatecall
-                        "," Int                     // gas to send with call
-                        "," Int                     // value to send with call
-                        "," Address                 // destination of call
-                        "," Data                    // data to send with call
-                        "," "[" LstSig "]" ")"      // list of signatures
+  syntax ExecParams ::= "(" AddressOrAny        // accepted msg.sender
+                        "," Address             // destination of call
+                        "," CallType            // call or delegatecall
+                        "," Int                 // gas to send with call
+                        "," Int                 // value to send with call
+                        "," Data                // data to send with call
+                        "," "[" LstSig "]" ")"  // list of signatures
 
   syntax FnCstr     ::= "constructor"
   syntax CstrParams ::= "(" Int                     // threshold

--- a/syntax.k
+++ b/syntax.k
@@ -16,9 +16,9 @@ module MINISIG-SYNTAX
   syntax LstOpt ::= List{Opt, ","}
 
   syntax FnView     ::= "nonce"
-                      | "threshold"
-                      | "DOMAIN_SEPARATOR"
-                      | "allSigners"
+                      /* | "threshold" */
+                      /* | "DOMAIN_SEPARATOR" */
+                      /* | "allSigners" */
   syntax ViewParams ::= "(" ")"
 
   syntax FnExec     ::= "execute"

--- a/test/msig-tests/execute-success.msig
+++ b/test/msig-tests/execute-success.msig
@@ -1,11 +1,10 @@
 setWorld
-    ecrecover [ {sig:"sigA1", op:Call, nonce:1, gas:5, val:1, dst:101, data:"data1"} ] := 55
-    ecrecover [ {sig:"sigB1", op:Call, nonce:1, gas:5, val:1, dst:101, data:"data1"} ] := 56
-    ecrecover [ {sig:"sigA2", op:DelegateCall, nonce:2, gas:5, val:1, dst:102, data:"data2"} ] := 55
-    ecrecover [ {sig:"sigB2", op:DelegateCall, nonce:2, gas:5, val:1, dst:102, data:"data2"} ] := 56
+    ecrecover [ {sig:"sigA1", src:Any, dst: 101, op:Call, nonce:1, gas:5, val:1, data:"data1"} ] := 55
+    ecrecover [ {sig:"sigB1", src:Any, dst:101, op:Call, nonce:1, gas:5, val:1, data:"data1"} ] := 56
+    ecrecover [ {sig:"sigA2", src:Any, dst:102, op:DelegateCall, nonce:2, gas:5, val:1, data:"data2"} ] := 55
+    ecrecover [ {sig:"sigB2", src:Any, dst:102, op:DelegateCall, nonce:2, gas:5, val:1, data:"data2"} ] := 56
 
     call-success      := [ true : true ]
-    codesize [ 102 ]  := 100
     gas-used-pre-call := 10
 
 setState
@@ -15,5 +14,5 @@ setState
     signers   := [ 55 : 56 : 57 ]
 
 sendTx
-    execute{value: 10, gas: 17}(Call, 5, 1, 101, "data1", [ "sigA1" : "sigB1" ])
-    execute{value: 1, gas: 17}(DelegateCall, 5, 1, 102, "data2", [ "sigA2" : "sigB2" ])
+    execute{value: 10, gas: 17}(Any, 101, Call, 5, 1, "data1", [ "sigA1" : "sigB1" ])
+    execute{value: 1, gas: 17}(Any, 102, DelegateCall, 5, 1, "data2", [ "sigA2" : "sigB2" ])

--- a/test/msig-tests/expect/execute-success.msig.expect
+++ b/test/msig-tests/expect/execute-success.msig.expect
@@ -23,28 +23,31 @@
     </signers>
   </msig-state>
   <call>
+    <caller>
+      0
+    </caller>
     <callvalue>
       0
     </callvalue>
-    <returndata>
-      true
-    </returndata>
     <callgas>
       17
     </callgas>
+    <returndata>
+      .RetVal
+    </returndata>
   </call>
   <log>
     <fn-log>
-      ListItem ( { fn: fn_execute ( DelegateCall , 5 , 1 , 102 , "data2" , [ "sigA2" : "sigB2" : .LstSig ] ) , callvalue: 1 , callgas: 17 } )
-      ListItem ( { fn: fn_execute ( Call , 5 , 1 , 101 , "data1" , [ "sigA1" : "sigB1" : .LstSig ] ) , callvalue: 10 , callgas: 17 } )
+      ListItem ( { fn: fn_execute ( Any , 102 , DelegateCall , 5 , 1 , "data2" , [ "sigA2" : "sigB2" : .LstSig ] ) , caller: 0 , callvalue: 1 , callgas: 17 } )
+      ListItem ( { fn: fn_execute ( Any , 101 , Call , 5 , 1 , "data1" , [ "sigA1" : "sigB1" : .LstSig ] ) , caller: 0 , callvalue: 10 , callgas: 17 } )
     </fn-log>
     <return-log>
-      ListItem ( true )
-      ListItem ( true )
+      ListItem ( .RetVal )
+      ListItem ( .RetVal )
     </return-log>
     <call-log>
-      ListItem ( { op: DelegateCall, gas: 5, val: 1, dst: 102, data: "data2" } )
-      ListItem ( { op: Call, gas: 5, val: 1, dst: 101, data: "data1" } )
+      ListItem ( { dst: 102, op: DelegateCall, gas: 5, val: 1, data: "data2" } )
+      ListItem ( { dst: 101, op: Call, gas: 5, val: 1, data: "data1" } )
     </call-log>
   </log>
   <prestate>
@@ -52,17 +55,14 @@
   </prestate>
   <world>
     <ecrecover>
-      {sig: "sigA1", op: Call, nonce: 1, gas: 5, val: 1, dst: 101, data: "data1"} |-> 55
-      {sig: "sigA2", op: DelegateCall, nonce: 2, gas: 5, val: 1, dst: 102, data: "data2"} |-> 55
-      {sig: "sigB1", op: Call, nonce: 1, gas: 5, val: 1, dst: 101, data: "data1"} |-> 56
-      {sig: "sigB2", op: DelegateCall, nonce: 2, gas: 5, val: 1, dst: 102, data: "data2"} |-> 56
+      {sig:"sigA1", src:Any, dst: 101, op:Call, nonce:1, gas:5, val:1, data:"data1"} |-> 55
+      {sig:"sigA2", src:Any, dst:102, op:DelegateCall, nonce:2, gas:5, val:1, data:"data2"} |-> 55
+      {sig:"sigB1", src:Any, dst:101, op:Call, nonce:1, gas:5, val:1, data:"data1"} |-> 56
+      {sig:"sigB2", src:Any, dst:102, op:DelegateCall, nonce:2, gas:5, val:1, data:"data2"} |->  56
     </ecrecover>
     <call-success>
       .List
     </call-success>
-    <codesize>
-      102 |-> 100
-    </codesize>
     <gas-used-pre-call>
       10
     </gas-used-pre-call>

--- a/test/test-harness-syntax.k
+++ b/test/test-harness-syntax.k
@@ -15,7 +15,6 @@ module TEST-HARNESS-SYNTAX
                     | StateExp StateExp [left]
 
   syntax WorldExp ::= "gas-used-pre-call"           ":=" Int
-                    | "codesize" "[" Address "]"    ":=" Int
                     | "ecrecover" "[" SignedMsg "]" ":=" Address
                     | "call-success"                ":=" "[" LstBool "]"
                     | WorldExp WorldExp [left]

--- a/test/test-harness.k
+++ b/test/test-harness.k
@@ -51,14 +51,6 @@ module TEST-HARNESS
     <gas-used-pre-call> _ => GASUSED </gas-used-pre-call>
 
   rule
-    <k> #set codesize [ ADDR ] := SIZE => . ...</k>
-    <codesize>... ADDR |-> ( _ => SIZE ) ...</codesize>
-  rule
-    <k> #set codesize [ ADDR ] := SIZE => . ...</k>
-    <codesize> RHO:Map ( .Map => ADDR |-> SIZE ) </codesize>
-  requires notBool ADDR in_keys(RHO)
-
-  rule
     <k> #set ecrecover [ SMSG ] := ADDR => . ...</k>
     <ecrecover>... SMSG |-> ( _ => ADDR ) ...</ecrecover>
   rule

--- a/types.k
+++ b/types.k
@@ -36,12 +36,12 @@ module MINISIG-TYPES
 
   rule nonce()            => #log fn_nonce()
                           ~> View ( Nonce )             [simplification]
-  rule threshold()        => #log fn_threshold()
-                          ~> View ( Thresh )            [simplification]
-  rule allSigners()       => #log fn_allSigners()
-                          ~> View ( Signers )           [simplification]
-  rule DOMAIN_SEPARATOR() => #log fn_DOMAIN_SEPARATOR()
-                          ~> View ( DomSep)             [simplification]
+  /* rule threshold()        => #log fn_threshold() */
+  /*                         ~> View ( Thresh )            [simplification] */
+  /* rule allSigners()       => #log fn_allSigners() */
+  /*                         ~> View ( Signers )           [simplification] */
+  /* rule DOMAIN_SEPARATOR() => #log fn_DOMAIN_SEPARATOR() */
+  /*                         ~> View ( DomSep)             [simplification] */
 
   rule execute ( SRC, DST, OP, GAS, VAL, DATA, [ SIGS ] )
     => #log fn_execute ( SRC , DST , OP , GAS , VAL , DATA , [ SIGS ] )

--- a/types.k
+++ b/types.k
@@ -13,10 +13,11 @@ module MINISIG-TYPES
 
   syntax OpView ::= "View" "(" ViewId ")"
 
-  syntax OpExec ::= "Exec" "(" CallType
-                           "," Int
-                           "," Int
+  syntax OpExec ::= "Exec" "(" AddressOrAny
                            "," Address
+                           "," CallType
+                           "," Int
+                           "," Int
                            "," Data
                            "," LstSig ")"
 
@@ -42,9 +43,9 @@ module MINISIG-TYPES
   rule DOMAIN_SEPARATOR() => #log fn_DOMAIN_SEPARATOR()
                           ~> View ( DomSep)             [simplification]
 
-  rule execute ( OP, GAS, VAL, DST, DATA, [ SIGS ] )
-    => #log fn_execute ( OP , GAS , VAL , DST , DATA , [ SIGS ] )
-    ~> Exec ( OP , GAS , VAL , DST , DATA , SIGS )      [simplification]
+  rule execute ( SRC, DST, OP, GAS, VAL, DATA, [ SIGS ] )
+    => #log fn_execute ( SRC , DST , OP , GAS , VAL , DATA , [ SIGS ] )
+    ~> Exec ( SRC , DST , OP , GAS , VAL , DATA , SIGS )      [simplification]
 
   rule constructor ( THRESHOLD , [ SIGNERS ] )
     => #log fn_constructor ( THRESHOLD , [ SIGNERS ] )
@@ -53,27 +54,28 @@ module MINISIG-TYPES
   // --- Signatures ---
 
   syntax SignedMsg ::= "{" "sig:"   Sig
+                       "," "src:"   AddressOrAny
+                       "," "dst:"   Address
                        "," "op:"    CallType
                        "," "nonce:" Int
-                       "," "gas:" Int
+                       "," "gas:"   Int
                        "," "val:"   Int
-                       "," "dst:"   Address
                        "," "data:"  Data "}"
 
   syntax LstSignedMsg ::= List{SignedMsg, ":"}
 
-  syntax SignedMsg ::= "#toSignedMsg" CallType Int Int Address Data Int Sig [function]
+  syntax SignedMsg ::= "#toSignedMsg" AddressOrAny Address CallType Int Int Data Int Sig [function]
 
-  rule #toSignedMsg OP GAS VAL DST DATA NONCE SIG
-    => { sig: SIG, op: OP, nonce: NONCE, gas: GAS, val: VAL, dst: DST, data: DATA }
+  rule #toSignedMsg SRC DST OP GAS VAL DATA NONCE SIG
+    => { sig: SIG, src: SRC, dst: DST, op: OP, nonce: NONCE, gas: GAS, val: VAL, data: DATA }
 
-  syntax LstSignedMsg ::= "#toLstSignedMsg" CallType Int Int Address Data Int LstSig [function]
+  syntax LstSignedMsg ::= "#toLstSignedMsg" AddressOrAny Address CallType Int Int Data Int LstSig [function]
 
-  rule #toLstSignedMsg _ _ _ _ _ _ .LstSig => .LstSignedMsg
+  rule #toLstSignedMsg _ _ _ _ _ _ _ .LstSig => .LstSignedMsg
 
-  rule #toLstSignedMsg OP GAS VAL DST DATA NONCE ( SIG : SIGS )
-    => #toSignedMsg OP GAS VAL DST DATA NONCE SIG
-       : #toLstSignedMsg OP GAS VAL DST DATA NONCE SIGS
+  rule #toLstSignedMsg SRC DST OP GAS VAL DATA NONCE ( SIG : SIGS )
+    => #toSignedMsg SRC DST OP GAS VAL DATA NONCE SIG
+       : #toLstSignedMsg SRC DST OP GAS VAL DATA NONCE SIGS
 
   // --- Errors and Logs ---
 
@@ -83,6 +85,7 @@ module MINISIG-TYPES
 
   syntax Error ::= "INVALID_VAL"
                  | "INVALID_CALLVAL"
+                 | "INVALID_CALLER"
                  | "DELEGATECALL_INVALID_CALLVAL"
                  | "PRESTATE_THRESHOLD_ZERO"
                  | "DELEGATECALL_DST_EMPTY_CODE"
@@ -103,21 +106,23 @@ module MINISIG-TYPES
                      | "fn_allSigners()"
                      | "fn_constructor" "(" Int
                                         "," "[" LstAddress "]" ")"
-                     | "fn_execute" "(" CallType
-                                    "," Int
-                                    "," Int
+                     | "fn_execute" "(" AddressOrAny
                                     "," Address
+                                    "," CallType
+                                    "," Int
+                                    "," Int
                                     "," Data
                                     "," "[" LstSig "]" ")"
 
   syntax FnLog ::= "{" "fn:"        FnDetails
+                   "," "caller:"    Address
                    "," "callvalue:" Int
                    "," "callgas:"   Int "}"
 
-  syntax CallLog ::= "{" "op:"   CallType
+  syntax CallLog ::= "{" "dst:"  Address
+                     "," "op:"   CallType
                      "," "gas:"  Int
                      "," "val:"  Int
-                     "," "dst:"  Address
                      "," "data:" Data "}"
 
   syntax RetVal ::= ".RetVal"
@@ -144,8 +149,10 @@ module MINISIG-TYPES
   rule #toSet X : XS => SetItem(X) ( #toSet XS )
 
   syntax Int ::= "pow8"   // 2 ^ 8
+               | "pow160" // 2 ^ 160
                | "pow256" // 2 ^ 256
   rule pow8   => 256 [macro]
+  rule pow160 => 1461501637330902918203684832716283019655932542976 [macro]
   rule pow256 => 115792089237316195423570985008687907853269984665640564039457584007913129639936 [macro]
 
   // the overhead required to check that gas remaing >= gas to send with call


### PR DESCRIPTION
* No `codesize` check on `delegatecall`
* No nonce check after `delegatecall`
* Ignore `_value` parameter on `delegatecall`
* Remove `threshold()`, `DOMAIN_SEPARATOR()`, and `allSigners()` getters -- available on-chain via `codecopy()`
```
execute(
    address _source,
    address _target,
    CallType _callType,
    uint256 _txGas,
    uint256 _value,
    bytes calldata _data,
    bytes calldata _sigs
)
    external
    payable
```

* Add `_source` parameter to restrict transaction submitter
* Remove `return true`